### PR TITLE
Feature to add Per-Player Name Holograms to NPCs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ install:
   - ls $HOME/.m2/repository/org/spigotmc/spigot/1.13.2-R0.1-SNAPSHOT >> /dev/null 2>&1 || java -jar BuildTools.jar --rev 1.13.2 >> /dev/null 2>&1
   - ls $HOME/.m2/repository/org/spigotmc/spigot/1.14.4-R0.1-SNAPSHOT >> /dev/null 2>&1 || java -jar BuildTools.jar --rev 1.14.4 >> /dev/null 2>&1
   - ls $HOME/.m2/repository/org/spigotmc/spigot/1.15.2-R0.1-SNAPSHOT >> /dev/null 2>&1 || java -jar BuildTools.jar --rev 1.15.2 >> /dev/null 2>&1
+  - ls $HOME/.m2/repository/org/spigotmc/spigot/1.16.1-R0.1-SNAPSHOT >> /dev/null 2>&1 || java -jar BuildTools.jar --rev 1.16.1 >> /dev/null 2>&1
 script:
   - mvn clean install

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>npclib</artifactId>
         <groupId>net.jitse</groupId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-api</artifactId>

--- a/api/src/main/java/net/jitse/npclib/api/NPC.java
+++ b/api/src/main/java/net/jitse/npclib/api/NPC.java
@@ -8,6 +8,7 @@ import net.jitse.npclib.api.skin.Skin;
 import net.jitse.npclib.api.state.NPCAnimation;
 import net.jitse.npclib.api.state.NPCSlot;
 import net.jitse.npclib.api.state.NPCState;
+import net.jitse.npclib.hologram.Hologram;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -17,6 +18,39 @@ import java.util.List;
 import java.util.UUID;
 
 public interface NPC {
+
+    /**
+     *
+     * @param player
+     * @return unique hologram for that user
+     */
+    Hologram getPlayerHologram(Player player);
+
+    /**
+     *
+     * @param uniqueLines The text that the targetPlayer will see
+     * @param targetPlayer The target player
+     * @return object instance
+     * @author Gatt
+     */
+    NPC setPlayerLines(List<String> uniqueLines, Player targetPlayer);
+
+    /**
+     *
+     * @param uniqueLines The text that the targetPlayer will see
+     * @param targetPlayer The target player
+     * @param update whether or not to send the update packets
+     * @return object instance
+     * @author Gatt
+     */
+    NPC setPlayerLines(List<String> uniqueLines, Player targetPlayer, boolean update);
+
+    /**
+     *
+     * @param targetPlayer The target player
+     * @return the lines that the targetPlayer will see, if null; default lines.
+     */
+    List<String> getPlayerLines(Player targetPlayer);
 
     /**
      * Set the NPC's location.

--- a/api/src/main/java/net/jitse/npclib/internal/MinecraftVersion.java
+++ b/api/src/main/java/net/jitse/npclib/internal/MinecraftVersion.java
@@ -16,7 +16,8 @@ public enum MinecraftVersion {
     V1_13_R1,
     V1_13_R2,
     V1_14_R1,
-    V1_15_R1;
+    V1_15_R1,
+    V1_16_R1;
 
     public boolean isAboveOrEqual(MinecraftVersion compare) {
         return ordinal() >= compare.ordinal();

--- a/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
+++ b/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
@@ -45,7 +45,8 @@ public abstract class NPCBase implements NPC, NPCPacketHandler {
     protected List<String> text;
     protected Location location;
     protected Skin skin;
-    protected Hologram hologram;
+
+    //protected Hologram hologram;
 
     protected final Map<NPCSlot, ItemStack> items = new EnumMap<>(NPCSlot.class);
 
@@ -90,7 +91,6 @@ public abstract class NPCBase implements NPC, NPCPacketHandler {
             Hologram hologram = getPlayerHologram(targetPlayer); //
             List<Object> updatePackets = hologram.getUpdatePackets(getPlayerLines(targetPlayer));
             hologram.update(targetPlayer, updatePackets);
-            hologram.show(targetPlayer);
         }
         return this;
     }
@@ -348,8 +348,8 @@ public abstract class NPCBase implements NPC, NPCPacketHandler {
         for (UUID shownUuid : shown) {
             Player player = Bukkit.getPlayer(shownUuid);
             if (player != null && isShown(player)) {
-                Hologram originalhologram = getPlayerHologram(player);
-                originalhologram.hide(player); // essentially destroy the hologram
+                Hologram originalHologram = getPlayerHologram(player);
+                originalHologram.hide(player); // essentially destroy the hologram
                 textDisplayHolograms.remove(player.getUniqueId()); // remove the old obj
                 Hologram hologram = getPlayerHologram(player); // let it regenerate
                 List<Object> updatePackets = hologram.getUpdatePackets(getPlayerLines(player));

--- a/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
+++ b/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
@@ -87,10 +87,12 @@ public abstract class NPCBase implements NPC, NPCPacketHandler {
                 originalhologram.hide(targetPlayer); // essentially destroy the hologram
                 textDisplayHolograms.remove(targetPlayer.getUniqueId()); // remove the old obj
             }
-
-            Hologram hologram = getPlayerHologram(targetPlayer); //
-            List<Object> updatePackets = hologram.getUpdatePackets(getPlayerLines(targetPlayer));
-            hologram.update(targetPlayer, updatePackets);
+            
+            if (isShown(targetPlayer)) { //only show hologram if the player is in range
+                Hologram hologram = getPlayerHologram(targetPlayer);
+                List<Object> updatePackets = hologram.getUpdatePackets(getPlayerLines(targetPlayer));
+                hologram.update(targetPlayer, updatePackets);
+            }
         }
         return this;
     }

--- a/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
+++ b/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
@@ -132,8 +132,9 @@ public abstract class NPCBase implements NPC, NPCPacketHandler {
             if (autoHidden.contains(uuid)) {
                 continue;
             }
-
-            hide(Bukkit.getPlayer(uuid), true);
+            Player plyr = Bukkit.getPlayer(uuid); // destroy the per player holograms
+            getPlayerHologram(plyr).hide(plyr);
+            hide(plyr, true);
         }
     }
 

--- a/api/src/main/java/net/jitse/npclib/internal/NPCPacketHandler.java
+++ b/api/src/main/java/net/jitse/npclib/internal/NPCPacketHandler.java
@@ -15,6 +15,8 @@ interface NPCPacketHandler {
 
     void createPackets();
 
+    void createPackets(Player player);
+
     void sendShowPackets(Player player);
 
     void sendHidePackets(Player player);

--- a/nms/pom.xml
+++ b/nms/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms</artifactId>

--- a/nms/v1_10_R1/pom.xml
+++ b/nms/v1_10_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_10_R1</artifactId>

--- a/nms/v1_10_R1/src/main/java/net/jitse/npclib/nms/v1_10_R1/NPC_v1_10_R1.java
+++ b/nms/v1_10_R1/src/main/java/net/jitse/npclib/nms/v1_10_R1/NPC_v1_10_R1.java
@@ -39,8 +39,23 @@ public class NPC_v1_10_R1 extends NPCBase {
     }
 
     @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_10_R1, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
+
+    @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_10_R1, location.clone().subtract(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -74,7 +89,7 @@ public class NPC_v1_10_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_10_R1/src/main/java/net/jitse/npclib/nms/v1_10_R1/NPC_v1_10_R1.java
+++ b/nms/v1_10_R1/src/main/java/net/jitse/npclib/nms/v1_10_R1/NPC_v1_10_R1.java
@@ -103,7 +103,7 @@ public class NPC_v1_10_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_11_R1/pom.xml
+++ b/nms/v1_11_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_11_R1</artifactId>

--- a/nms/v1_11_R1/src/main/java/net/jitse/npclib/nms/v1_11_R1/NPC_v1_11_R1.java
+++ b/nms/v1_11_R1/src/main/java/net/jitse/npclib/nms/v1_11_R1/NPC_v1_11_R1.java
@@ -39,8 +39,23 @@ public class NPC_v1_11_R1 extends NPCBase {
     }
 
     @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_11_R1, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
+
+    @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_11_R1, location.clone().add(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -74,7 +89,7 @@ public class NPC_v1_11_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_11_R1/src/main/java/net/jitse/npclib/nms/v1_11_R1/NPC_v1_11_R1.java
+++ b/nms/v1_11_R1/src/main/java/net/jitse/npclib/nms/v1_11_R1/NPC_v1_11_R1.java
@@ -103,7 +103,7 @@ public class NPC_v1_11_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_12_R1/pom.xml
+++ b/nms/v1_12_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_12_R1</artifactId>

--- a/nms/v1_12_R1/src/main/java/net/jitse/npclib/nms/v1_12_R1/NPC_v1_12_R1.java
+++ b/nms/v1_12_R1/src/main/java/net/jitse/npclib/nms/v1_12_R1/NPC_v1_12_R1.java
@@ -103,7 +103,7 @@ public class NPC_v1_12_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_12_R1/src/main/java/net/jitse/npclib/nms/v1_12_R1/NPC_v1_12_R1.java
+++ b/nms/v1_12_R1/src/main/java/net/jitse/npclib/nms/v1_12_R1/NPC_v1_12_R1.java
@@ -39,8 +39,23 @@ public class NPC_v1_12_R1 extends NPCBase {
     }
 
     @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_12_R1, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
+
+    @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_12_R1, location.clone().add(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -74,7 +89,7 @@ public class NPC_v1_12_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_13_R1/pom.xml
+++ b/nms/v1_13_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_13_R1</artifactId>

--- a/nms/v1_13_R1/src/main/java/net/jitse/npclib/nms/v1_13_R1/NPC_v1_13_R1.java
+++ b/nms/v1_13_R1/src/main/java/net/jitse/npclib/nms/v1_13_R1/NPC_v1_13_R1.java
@@ -103,7 +103,7 @@ public class NPC_v1_13_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_13_R1/src/main/java/net/jitse/npclib/nms/v1_13_R1/NPC_v1_13_R1.java
+++ b/nms/v1_13_R1/src/main/java/net/jitse/npclib/nms/v1_13_R1/NPC_v1_13_R1.java
@@ -39,8 +39,23 @@ public class NPC_v1_13_R1 extends NPCBase {
     }
 
     @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_13_R1, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
+
+    @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_13_R1, location.clone().add(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -74,7 +89,7 @@ public class NPC_v1_13_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_13_R2/pom.xml
+++ b/nms/v1_13_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_13_R2</artifactId>

--- a/nms/v1_13_R2/src/main/java/net/jitse/npclib/nms/v1_13_R2/NPC_v1_13_R2.java
+++ b/nms/v1_13_R2/src/main/java/net/jitse/npclib/nms/v1_13_R2/NPC_v1_13_R2.java
@@ -37,10 +37,24 @@ public class NPC_v1_13_R2 extends NPCBase {
     public NPC_v1_13_R2(NPCLib instance, List<String> lines) {
         super(instance, lines);
     }
+    @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_13_R2, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
 
     @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_13_R2, location.clone().add(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -74,7 +88,7 @@ public class NPC_v1_13_R2 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_13_R2/src/main/java/net/jitse/npclib/nms/v1_13_R2/NPC_v1_13_R2.java
+++ b/nms/v1_13_R2/src/main/java/net/jitse/npclib/nms/v1_13_R2/NPC_v1_13_R2.java
@@ -102,7 +102,7 @@ public class NPC_v1_13_R2 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_14_R1/pom.xml
+++ b/nms/v1_14_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_14_R1</artifactId>

--- a/nms/v1_14_R1/src/main/java/net/jitse/npclib/nms/v1_14_R1/NPC_v1_14_R1.java
+++ b/nms/v1_14_R1/src/main/java/net/jitse/npclib/nms/v1_14_R1/NPC_v1_14_R1.java
@@ -33,10 +33,24 @@ public class NPC_v1_14_R1 extends NPCBase {
     public NPC_v1_14_R1(NPCLib instance, List<String> lines) {
         super(instance, lines);
     }
+    @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_14_R1, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
 
     @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_14_R1, location.clone().add(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -70,7 +84,7 @@ public class NPC_v1_14_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_14_R1/src/main/java/net/jitse/npclib/nms/v1_14_R1/NPC_v1_14_R1.java
+++ b/nms/v1_14_R1/src/main/java/net/jitse/npclib/nms/v1_14_R1/NPC_v1_14_R1.java
@@ -98,7 +98,7 @@ public class NPC_v1_14_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_15_R1/pom.xml
+++ b/nms/v1_15_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_15_R1</artifactId>

--- a/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/NPC_v1_15_R1.java
+++ b/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/NPC_v1_15_R1.java
@@ -33,10 +33,24 @@ public class NPC_v1_15_R1 extends NPCBase {
     public NPC_v1_15_R1(NPCLib instance, List<String> lines) {
         super(instance, lines);
     }
+    @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_15_R1, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
 
     @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_15_R1, location.clone().add(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -71,7 +85,7 @@ public class NPC_v1_15_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
         sendMetadataPacket(player);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/NPC_v1_15_R1.java
+++ b/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/NPC_v1_15_R1.java
@@ -99,7 +99,7 @@ public class NPC_v1_15_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_16_R1/pom.xml
+++ b/nms/v1_16_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_16_R1</artifactId>

--- a/nms/v1_16_R1/src/main/java/net/jitse/npclib/nms/v1_16_R1/NPC_v1_16_R1.java
+++ b/nms/v1_16_R1/src/main/java/net/jitse/npclib/nms/v1_16_R1/NPC_v1_16_R1.java
@@ -102,7 +102,7 @@ public class NPC_v1_16_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_16_R1/src/main/java/net/jitse/npclib/nms/v1_16_R1/NPC_v1_16_R1.java
+++ b/nms/v1_16_R1/src/main/java/net/jitse/npclib/nms/v1_16_R1/NPC_v1_16_R1.java
@@ -36,10 +36,24 @@ public class NPC_v1_16_R1 extends NPCBase {
     public NPC_v1_16_R1(NPCLib instance, List<String> lines) {
         super(instance, lines);
     }
+    @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_16_R1, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
 
     @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_15_R1, location.clone().add(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -74,7 +88,7 @@ public class NPC_v1_16_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
         sendMetadataPacket(player);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_8_R2/pom.xml
+++ b/nms/v1_8_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_8_R2</artifactId>

--- a/nms/v1_8_R2/src/main/java/net/jitse/npclib/nms/v1_8_R2/NPC_v1_8_R2.java
+++ b/nms/v1_8_R2/src/main/java/net/jitse/npclib/nms/v1_8_R2/NPC_v1_8_R2.java
@@ -103,7 +103,7 @@ public class NPC_v1_8_R2 extends NPCBase {
 
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_8_R2/src/main/java/net/jitse/npclib/nms/v1_8_R2/NPC_v1_8_R2.java
+++ b/nms/v1_8_R2/src/main/java/net/jitse/npclib/nms/v1_8_R2/NPC_v1_8_R2.java
@@ -39,8 +39,23 @@ public class NPC_v1_8_R2 extends NPCBase {
     }
 
     @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_8_R2, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
+
+    @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_8_R2, location.clone().add(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -64,6 +79,7 @@ public class NPC_v1_8_R2 extends NPCBase {
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
     }
 
+
     @Override
     public void sendShowPackets(Player player) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
@@ -74,7 +90,7 @@ public class NPC_v1_8_R2 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_8_R3/pom.xml
+++ b/nms/v1_8_R3/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_8_R3</artifactId>

--- a/nms/v1_8_R3/src/main/java/net/jitse/npclib/nms/v1_8_R3/NPC_v1_8_R3.java
+++ b/nms/v1_8_R3/src/main/java/net/jitse/npclib/nms/v1_8_R3/NPC_v1_8_R3.java
@@ -39,8 +39,22 @@ public class NPC_v1_8_R3 extends NPCBase {
     }
 
     @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_8_R3, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
+    @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_8_R3, location.clone().add(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -74,7 +88,7 @@ public class NPC_v1_8_R3 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_8_R3/src/main/java/net/jitse/npclib/nms/v1_8_R3/NPC_v1_8_R3.java
+++ b/nms/v1_8_R3/src/main/java/net/jitse/npclib/nms/v1_8_R3/NPC_v1_8_R3.java
@@ -102,7 +102,7 @@ public class NPC_v1_8_R3 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_9_R1/pom.xml
+++ b/nms/v1_9_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_9_R1</artifactId>

--- a/nms/v1_9_R1/src/main/java/net/jitse/npclib/nms/v1_9_R1/NPC_v1_9_R1.java
+++ b/nms/v1_9_R1/src/main/java/net/jitse/npclib/nms/v1_9_R1/NPC_v1_9_R1.java
@@ -103,7 +103,7 @@ public class NPC_v1_9_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_9_R1/src/main/java/net/jitse/npclib/nms/v1_9_R1/NPC_v1_9_R1.java
+++ b/nms/v1_9_R1/src/main/java/net/jitse/npclib/nms/v1_9_R1/NPC_v1_9_R1.java
@@ -39,8 +39,23 @@ public class NPC_v1_9_R1 extends NPCBase {
     }
 
     @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_9_R1, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
+
+    @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_9_R1, location.clone().subtract(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -74,7 +89,7 @@ public class NPC_v1_9_R1 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/nms/v1_9_R2/pom.xml
+++ b/nms/v1_9_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib-nms</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-nms-v1_9_R2</artifactId>

--- a/nms/v1_9_R2/src/main/java/net/jitse/npclib/nms/v1_9_R2/NPC_v1_9_R2.java
+++ b/nms/v1_9_R2/src/main/java/net/jitse/npclib/nms/v1_9_R2/NPC_v1_9_R2.java
@@ -104,7 +104,7 @@ public class NPC_v1_9_R2 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutEntityDestroy);
         playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
 
-        hologram.hide(player);
+        getPlayerHologram(player).hide(player);
     }
 
     @Override

--- a/nms/v1_9_R2/src/main/java/net/jitse/npclib/nms/v1_9_R2/NPC_v1_9_R2.java
+++ b/nms/v1_9_R2/src/main/java/net/jitse/npclib/nms/v1_9_R2/NPC_v1_9_R2.java
@@ -39,8 +39,24 @@ public class NPC_v1_9_R2 extends NPCBase {
     }
 
     @Override
+    public Hologram getPlayerHologram(Player player) {
+        Hologram holo = super.getPlayerHologram(player);
+        if (holo == null){
+            holo = new Hologram(MinecraftVersion.V1_9_R2, location.clone().add(0, 0.5, 0), getPlayerLines(player));
+        }
+        super.textDisplayHolograms.put(player.getUniqueId(), holo);
+        return holo;
+    }
+
+
+
+    @Override
     public void createPackets() {
-        this.hologram = new Hologram(MinecraftVersion.V1_9_R2, location.clone().subtract(0, 0.5, 0), text);
+        Bukkit.getOnlinePlayers().forEach(this::createPackets);
+    }
+
+    @Override
+    public void createPackets(Player player) {
 
         PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
 
@@ -74,7 +90,7 @@ public class NPC_v1_9_R2 extends NPCBase {
         playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
         playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
 
-        hologram.show(player);
+        getPlayerHologram(player).show(player);
 
         // Removing the player info after 10 seconds.
         Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.jitse</groupId>
         <artifactId>npclib</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>npclib-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.jitse</groupId>
     <artifactId>npclib</artifactId>
-    <version>2.9-SNAPSHOT</version>
+    <version>2.10-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This pull request adds per-user holograms that, if implemented by a developer can allow for per-user placeholder text that can vary from player to player.

The pull request also bumps the version to 2.10-SNAPSHOT, and potentially fixes the `.travis.yml` file to include downloading Spigot 1.16.1.

![image](https://user-images.githubusercontent.com/1311244/87670167-a97eff80-c7b2-11ea-8b47-0832dd39ba4b.png)
![javaw_8TkU3pDJ09](https://user-images.githubusercontent.com/1311244/87670211-b865b200-c7b2-11ea-81ec-60eabc34dfe3.png)
