### PR TITLE
Set global text variable when setText called

### DIFF
--- a/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
+++ b/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
@@ -108,6 +108,7 @@ public abstract class NPCBase implements NPC, NPCPacketHandler {
 
     @Override
     public NPC setText(List<String> text) {
+        this.text = text;
         for (UUID uuid : shown) {
             Player player = Bukkit.getPlayer(uuid);
             if (player == null) continue;


### PR DESCRIPTION
This allows `getText()` without any specified player to correct retrieve the npc's text. Currently, if you set the text for all players, and then retrieve it without specifying a player, it will return an empty list.